### PR TITLE
This fixes error "this.fixButton is not a function"

### DIFF
--- a/lib/panelview.js
+++ b/lib/panelview.js
@@ -21,9 +21,7 @@ const { panelviewContract } = require("./panelview/contract");
 
 var views = new WeakMap();
 
-function viewFor(panelview) {
-    return views.get(panelview);
-}
+function viewFor(panelview) views.get(panelview);
 
 const PanelView = Class({
     implements: [

--- a/lib/panelview.js
+++ b/lib/panelview.js
@@ -21,7 +21,9 @@ const { panelviewContract } = require("./panelview/contract");
 
 var views = new WeakMap();
 
-function viewFor(panelview) views.get(panelview);
+function viewFor(panelview) {
+    return views.get(panelview);
+}
 
 const PanelView = Class({
     implements: [

--- a/lib/panelview/workaround.js
+++ b/lib/panelview/workaround.js
@@ -18,7 +18,7 @@ exports.applyButtonFix = function(button) {
 
     let bWindows = windows();
     for(var w in bWindows)
-        this.fixButton(button, bWindows[w]);
+        exports.fixButton(button, bWindows[w]);
 
     var buttonId = getNodeView(button).id,
         CUI = CustomizableUI,


### PR DESCRIPTION
A very small fix but I stumbled on this issue when I import your "fixButton" using object destructuring assignment, like so: "var {fixButton} = require('...');".
The other change was just to get rid of the IDE warnings as it does not understand function expression closures because it is not a standard js feature.